### PR TITLE
Serverless should remove app.listen

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,8 +43,4 @@ db.once('open', () => {
 
 app.use('/', require('./routes'))
 
-app.listen(port, () => {
-  console.log(`Server is now running on http://localhost:${port}`)
-})
-
 module.exports.handler = serverless(app)


### PR DESCRIPTION
```
app.listen(port, () => {
  console.log(`Server is now running on http://localhost:${port}`)
}) 
```
should be removed